### PR TITLE
Proposed fix to the error reported by CPAN Tester

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,8 @@ version = 0.15
 [@Basic]
 [PkgVersion]
 [AutoPrereqs]
+[Prereqs]
+File::HomeDir = 0.93 ; to get method my_dist_data()
 [NextRelease]
 format = %-4v %{yyyy-MM-dd}d NEILB
 

--- a/dist.ini
+++ b/dist.ini
@@ -9,8 +9,6 @@ version = 0.15
 [@Basic]
 [PkgVersion]
 [AutoPrereqs]
-[Prereqs]
-File::HomeDir = 0.93 ; to get method my_dist_data()
 [NextRelease]
 format = %-4v %{yyyy-MM-dd}d NEILB
 

--- a/lib/PAUSE/Packages.pm
+++ b/lib/PAUSE/Packages.pm
@@ -7,7 +7,7 @@ use Moo 1.006;
 
 use CPAN::DistnameInfo;
 use Carp;
-use File::HomeDir;
+use File::HomeDir 0.93;
 use File::Spec::Functions 'catfile';
 use HTTP::Date qw(time2str);
 use HTTP::Tiny;


### PR DESCRIPTION
Hi Neil,

I propose fix to the test failure as below:

  http://www.cpantesters.org/cpan/report/b9217450-2c7f-11e5-816f-3c7ce14af301

The distribution using method my_dist_data() from the package File::HomeDIr. However the method my_dist_data() is only introduced 0.92_01 onwards but "dist.ini" is not imposing version check.

I have updated dist.ini to make the minimum version check as v0.93.

Please review it.

Many Thanks.

Best Regards,
Mohammad S Anwar
