### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: Perl
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        perl: [ '5.30', '5.36' ]
+        exclude:
+          - runner: windows-latest
+            perl: '5.36'
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Perl ${{matrix.perl}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up perl
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+          perl-version: ${{ matrix.perl }}
+          distribution: ${{ ( startsWith( matrix.runner, 'windows-' ) && 'strawberry' ) || 'default' }}
+
+    - name: Show Perl Version
+      run: |
+        perl -v
+
+    - name: Install Dist::Zilla
+      run: |
+        cpanm -v
+        cpanm --notest Dist::Zilla
+
+    - name: Install Modules
+      run: |
+        dzil authordeps --missing | cpanm --notest
+        dzil listdeps --missing | cpanm --notest
+
+   - name: Show Errors on Windows
+      if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
+      run: |
+         ls -l C:/Users/
+         ls -l C:/Users/RUNNER~1/
+         cat C:/Users/runneradmin/.cpanm/work/*/build.log
+
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
+
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
+
+    - name: Run tests
+      run: |
+        dzil test
+
+ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,17 @@ jobs:
          ls -l C:/Users/RUNNER~1/
          cat C:/Users/runneradmin/.cpanm/work/*/build.log
 
-    - name: Show Errors on Ubuntu
-      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
-      run: |
-         cat /home/runner/.cpanm/work/*/build.log
+   - name: Show Errors on Ubuntu
+     if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+     run: |
+        cat /home/runner/.cpanm/work/*/build.log
 
-    - name: Show Errors on OSX
-      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
-      run: |
-         cat  /Users/runner/.cpanm/work/*/build.log
+   - name: Show Errors on OSX
+     if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+     run: |
+        cat  /Users/runner/.cpanm/work/*/build.log
 
-    - name: Run tests
-      run: |
-        dzil test
+   - name: Run tests
+     run: |
+       dzil test
 
- 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, macos-latest, windows-latest]
+        runner: [ubuntu-latest, macos-latest] # , windows-latest
         perl: [ '5.30', '5.36' ]
-        exclude:
-          - runner: windows-latest
-            perl: '5.36'
+        #exclude:
+        #  - runner: windows-latest
+        #    perl: '5.36'
 
     runs-on: ${{matrix.runner}}
     name: OS ${{matrix.runner}} Perl ${{matrix.perl}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Perl
+name: CI
 
 on:
   push:
@@ -42,24 +42,24 @@ jobs:
         dzil authordeps --missing | cpanm --notest
         dzil listdeps --missing | cpanm --notest
 
-   - name: Show Errors on Windows
+    - name: Show Errors on Windows
       if:  ${{ failure() && startsWith( matrix.runner, 'windows-')}}
       run: |
          ls -l C:/Users/
          ls -l C:/Users/RUNNER~1/
          cat C:/Users/runneradmin/.cpanm/work/*/build.log
 
-   - name: Show Errors on Ubuntu
-     if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
-     run: |
-        cat /home/runner/.cpanm/work/*/build.log
+    - name: Show Errors on Ubuntu
+      if:  ${{ failure() && startsWith( matrix.runner, 'ubuntu-')}}
+      run: |
+         cat /home/runner/.cpanm/work/*/build.log
 
-   - name: Show Errors on OSX
-     if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
-     run: |
-        cat  /Users/runner/.cpanm/work/*/build.log
+    - name: Show Errors on OSX
+      if:  ${{ failure() && startsWith( matrix.runner, 'macos-')}}
+      run: |
+         cat  /Users/runner/.cpanm/work/*/build.log
 
-   - name: Run tests
-     run: |
-       dzil test
+    - name: Run tests
+      run: |
+        dzil test
 


### PR DESCRIPTION
As mentioned in the Perl Weekly as well, I am on a quest to enable Continuous Integration (CI) and improve testing on all the CPAN modules where the author is interested in it. Having CI configured will provide fast feedback to the author(s) and will reduce the chances of releasing a module that only works on the computer of the developer. Currently GitHub Actions is the most natural CI system for GitHub-based projects. That's why I am sending this PR.

I've enabled several versions of Perl on 2 different platforms. On Windows the tests fail. If you feel it is important to
make the module run on Windows as well, you can enable the CI on Windows as well.

I have written several blog posts and recorded videos on the subject. You can find them here: https://perlmaven.com/os
If you need further help with the CI system, feel free to ask me.
If you'd like to support my efforts there are several ways to do so https://szabgab.com/support.html